### PR TITLE
Add multiprocessing form of features

### DIFF
--- a/satsense/extract.py
+++ b/satsense/extract.py
@@ -1,22 +1,150 @@
+import resource
+import time
+from functools import partial
+from multiprocessing import Pool
+from multiprocessing import cpu_count
+
 import numpy as np
+from numba import njit
 from six import iteritems
 
+from satsense.features import FeatureSet
+from satsense.generators import CellGenerator
+from satsense.util.cache import load_cache, cache
 
-def extract_features(features, generator):
-    shape = generator.shape
 
-    total_length = features.index_size
-    print("Total length found: ", total_length)
-    feature_vector = np.zeros((shape[0], shape[1], total_length))
-    print("Feature vector:")
-    print(feature_vector.shape)
+def timing(f):
+    """
+    Decorator to time function in minutes
+    """
 
-    for feature in features.items.values():
+    def wrap(*args):
+        time1 = time.time()
+        ret = f(*args)
+        time2 = time.time()
+        print('%s function took %0.3f minutes' % (f.__name__, (time2 - time1) / 60))
+        return ret
+
+    return wrap
+
+
+@timing
+def extract_features(features: FeatureSet, generator: CellGenerator, load_cached=True, image_name=""):
+    start = time.time()
+    shape = generator.shape()
+
+    shared_feature_matrix = np.zeros((shape[0], shape[1], 1))
+    print("\n--- Calculating Feature vector: {} ---\n".format(shared_feature_matrix.shape))
+
+    for name, feature in iteritems(features.items):
+        cache_key = "feature-{feature}-window{window}-image-{image_name}".format(
+            image_name=image_name,
+            window=(generator.x_size, generator.y_size),
+            feature=str(feature),
+        )
+
+        feature_matrix = None
+        if "Te-" not in str(feature):
+            feature_matrix = load_cache(cache_key)
+
+        if feature_matrix is None:
+            feature_matrix = compute_feature(feature, generator)
+            cache(feature_matrix, cache_key)
+
+        if shared_feature_matrix:
+            shared_feature_matrix = np.append(shared_feature_matrix, feature_matrix, axis=2)
+        else:
+            shared_feature_matrix = feature_matrix
+
+            # Dirty fix. Would be better to re-use the windows every time so that
+        # the windows do not have to be recalculated
+        # (generator can only be iterated over once)
+        generator = CellGenerator(generator.image, (generator.x_size, generator.y_size))
+
+    end = time.time()
+    print("Elapsed time extract multiprocessing: {} minutes, start: {}, end: {}".format((end - start) / 60, start, end))
+
+    return shared_feature_matrix
+
+
+@timing
+def compute_feature(feature, generator):
+    print("\n--- Calculating feature: {} ---\n".format(feature))
+
+    start = time.time()
+
+    shape = generator.shape()
+    scales_feature_matrix = None
+    # Calculate for different scales separately.
+    for scale in feature.windows:
+        # Prepare data for multiprocessing of individual features
+        # Every feature needs 'initialize' option to work
         if hasattr(feature, 'initialize'):
-            feature.initialize(generator.image)
+            data = feature.initialize(generator, scale)
+        else:
+            raise ValueError("Initialize not implemented")
 
-    for cell in generator:
-        for name, feature in iteritems(features.items):
-            feature_vector[cell.x, cell.y, feature.indices] = feature(cell)
+        end = time.time()
+        print("Preparing data cells took {} seconds".format((end - start)))
 
-    return feature_vector
+        chunk_size = shape[0]
+        cpu_cnt = cpu_count()
+
+        # Get chunk size if feature has that function
+        if hasattr(feature, 'chunk_size'):
+            chunk_size = feature.chunk_size(cpu_cnt, shape)
+
+        windows_chunked = [data[i:i + chunk_size] for i in range(0, len(data), chunk_size)]
+        total_chunks = len(windows_chunked)
+
+        print("\nTotal chunks to compute: {}, chunk_size: {}".format(total_chunks, chunk_size))
+
+        p = Pool(cpu_cnt, maxtasksperchild=1)
+        compute_chunk_f = partial(compute_chunk, feature=feature)
+        processing_results = p.map(compute_chunk_f, windows_chunked, chunksize=1)
+        p.close()
+        p.join()
+
+        # Load individual results of processing back into one matrix
+        feature_matrix = np.zeros((shape[0], shape[1], feature.feature_size))
+        for coords, chunk_matrix in processing_results:
+            load_results_into_matrix(feature_matrix, coords, chunk_matrix)
+
+        if scales_feature_matrix:
+            scales_feature_matrix = np.append(scales_feature_matrix, feature_matrix, axis=2)
+        else:
+            scales_feature_matrix = feature_matrix
+
+        # Dirty fix. Would be better to re-use the windows every time so that
+        # the windows do not have to be recalculated
+        # (generator can only be iterated over once)
+        generator = CellGenerator(generator.image, (generator.x_size, generator.y_size))
+
+    return scales_feature_matrix
+
+
+@njit
+def load_results_into_matrix(feature_matrix, coords, chunk_matrix):
+    for i in range(coords.shape[0]):
+        x = int(coords[i, 0])
+        y = int(coords[i, 1])
+        fv = chunk_matrix[i, :]
+        feature_matrix[x, y, :] = fv
+
+
+def compute_chunk(chunk, feature):
+    start = time.time()
+
+    result = feature(chunk)
+
+    end = time.time()
+    delta = (end - start)
+    per_block = delta / len(chunk)
+    mem_usage = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+
+    print(
+        "Calculating {} Windows took {} seconds,"
+        " each window took: {} (avg), mem:{}".format(len(chunk), delta, per_block,
+                                                     mem_usage))
+
+    return result

--- a/satsense/features/feature.py
+++ b/satsense/features/feature.py
@@ -1,4 +1,5 @@
 from abc import ABCMeta, abstractmethod
+from collections import OrderedDict
 
 from six import iteritems
 
@@ -12,6 +13,9 @@ class Feature(object):
     def __init__(self):
         self._indices = None
         self._length = 0
+
+    def __str__(self):
+        return self.__class__.__name__
 
     @abstractmethod
     def __call__(self):
@@ -36,11 +40,17 @@ class Feature(object):
 
 class FeatureSet(object):
     def __init__(self):
-        self._features = {}
+        self._features = OrderedDict()
         self._cur_index = 0
 
     def __iter__(self):
         return iter(self._features)
+
+    def __str__(self):
+        return self.string_presentation()
+
+    def string_presentation(self):
+        return "_".join([str(f) for k, f in self._features.items()])
 
     @property
     def items(self):
@@ -48,7 +58,7 @@ class FeatureSet(object):
 
     def add(self, feature, name=None):
         if not name:
-            name = "{0}-{1}".format(feature.__class__.__name__,
+            name = "{0}-{1}".format(feature.__class__.__name__.upper(),
                                     len(self._features) + 1)
 
         self._features[name] = (feature)

--- a/satsense/features/sift.py
+++ b/satsense/features/sift.py
@@ -7,6 +7,8 @@ from sklearn.cluster import MiniBatchKMeans
 
 from .. import SatelliteImage
 from .feature import Feature
+from satsense.generators import CellGenerator
+from satsense.generators.cell_generator import super_cell
 
 
 def sift_cluster(sat_images: Iterator[SatelliteImage],
@@ -36,12 +38,43 @@ def sift_cluster(sat_images: Iterator[SatelliteImage],
     return mbkmeans
 
 
+def sift_for_chunk(chunk, kmeans, normalized=True):
+    chunk_len = len(chunk)
+    cluster_count = kmeans.n_clusters
+    sift_obj = cv2.xfeatures2d.SIFT_create()
+
+    coords = np.zeros((chunk_len, 2))
+    chunk_matrix = np.zeros((chunk_len, cluster_count), dtype=np.float64)
+    for i in range(chunk_len):
+        coords[i, :] = chunk[i][0:2]
+
+        win_gray_ubyte = chunk[i][2]
+
+        kp, descriptors = sift_obj.detectAndCompute(win_gray_ubyte, None)
+        del kp  # Free up memory
+
+        if descriptors is None:
+            chunk_matrix[i, :] = np.zeros((cluster_count), dtype=np.int32)
+            continue
+
+        codewords = kmeans.predict(descriptors)
+        counts = np.bincount(codewords, minlength=cluster_count)
+
+        # Perform normalization
+        if normalized:
+            counts = counts / cluster_count
+
+        chunk_matrix[i, :] = counts
+
+    return coords, chunk_matrix
+
+
 class Sift(Feature):
     """Sift feature."""
 
     def __init__(self,
                  kmeans: MiniBatchKMeans,
-                 windows=((25, 25), ),
+                 windows=((25, 25),),
                  normalized=True):
         """Create sift feature."""
         super(Sift, self)
@@ -51,37 +84,19 @@ class Sift(Feature):
         self.sift_obj = cv2.xfeatures2d.SIFT_create()
         self.normalized = normalized
 
-    def __call__(self, cell):
-        result = np.zeros(self.feature_size)
-        n_clusters = self.kmeans.n_clusters
-        for i, window in enumerate(self.windows):
-            win = cell.super_cell(window, padding=True)
-            start_index = i * n_clusters
-            end_index = (i + 1) * n_clusters
-            result[start_index:end_index] = self.sift(win.gray_ubyte,
-                                                      self.kmeans)
-        return result
+    def __call__(self, chunk):
+        return sift_for_chunk(chunk, self.kmeans, self.normalized)
 
     def __str__(self):
-        normalized = "normalized" if self.normalized else "not-normalized"
-        return "Sift-{}-{}".format(str(self.windows), normalized)
+        normalized = "n" if self.normalized == True else "nn"
+        return "Si-{}{}".format(str(self.windows), normalized)
 
-    def sift(self, window_gray_ubyte, kmeans: MiniBatchKMeans):
-        """Calculate the sift feature on the given window."""
-        _, descriptors = self.sift_obj.detectAndCompute(
-            window_gray_ubyte, None)
-        del _  # Free up memory
+    def initialize(self, generator: CellGenerator, scale):
+        data = []
+        for window in generator:
+            win_gray_ubyte, _, _ = super_cell(generator.image.gray_ubyte, scale, window.x_range, window.y_range,
+                                              padding=False)
+            processing_tuple = (window.x, window.y, win_gray_ubyte)
+            data.append(processing_tuple)
 
-        # Is none if no descriptors are found, i.e. on 0 input range
-        cluster_count = kmeans.n_clusters
-        if descriptors is None:
-            return np.zeros((cluster_count))
-
-        codewords = kmeans.predict(descriptors)
-        counts = np.bincount(codewords, minlength=cluster_count)
-
-        # Perform normalization
-        if self.normalized:
-            counts = counts / cluster_count
-
-        return counts
+        return data

--- a/satsense/features/texton.py
+++ b/satsense/features/texton.py
@@ -1,4 +1,5 @@
 """Texton feature implementation."""
+from functools import lru_cache
 from typing import Iterator
 
 import numpy as np
@@ -6,8 +7,9 @@ from scipy import ndimage
 from skimage.filters import gabor_kernel, gaussian
 from sklearn.cluster import MiniBatchKMeans
 
-from .. import SatelliteImage
-from ..generators.cell_generator import Cell
+from satsense import SatelliteImage
+from satsense.generators import CellGenerator
+from satsense.generators.cell_generator import super_cell
 from .feature import Feature
 
 
@@ -40,6 +42,7 @@ def texton_cluster(sat_images: Iterator[SatelliteImage],
     return mbkmeans
 
 
+@lru_cache(maxsize=1)
 def create_kernels():
     """Create filter bank kernels."""
     kernels = []
@@ -47,11 +50,10 @@ def create_kernels():
     thetas = np.linspace(0, np.pi, angles)
     for theta in thetas:
         # theta = theta / 8. * np.pi
-        for sigma in (1, ):
-            for frequency in (0.05, ):
-                kernel = np.real(
-                    gabor_kernel(
-                        frequency, theta=theta, sigma_x=sigma, sigma_y=sigma))
+        for sigma in (1,):
+            for frequency in (0.05, 0.25):
+                kernel = np.real(gabor_kernel(frequency, theta=theta,
+                                              sigma_x=sigma, sigma_y=sigma))
                 kernels.append(kernel)
 
     return kernels
@@ -59,11 +61,9 @@ def create_kernels():
 
 def get_texton_descriptors(image):
     """Compute texton descriptors."""
-    print("Computing texton descriptors for image with shape {}"
-          .format(image.shape))
     kernels = create_kernels()
     length = len(kernels) + 1
-    descriptors = np.zeros(image.shape + (length, ), dtype=np.double)
+    descriptors = np.zeros(image.shape + (length,), dtype=np.double)
     for k, kernel in enumerate(kernels):
         descriptors[:, :, k] = ndimage.convolve(image, kernel, mode='wrap')
 
@@ -74,13 +74,40 @@ def get_texton_descriptors(image):
     return descriptors
 
 
+def texton_for_chunk(chunk, kmeans, normalized=True):
+    chunk_len = len(chunk)
+    cluster_count = kmeans.n_clusters
+
+    coords = np.zeros((chunk_len, 2))
+    chunk_matrix = np.zeros((chunk_len, cluster_count))
+    for i in range(chunk_len):
+        coords[i, :] = chunk[i][0:2]
+
+        im_grayscale = chunk[i][2]
+        sub_descriptors = get_texton_descriptors(im_grayscale)
+
+        # Calculate Difference-of-Gaussian
+        dog = np.expand_dims(gaussian(im_grayscale, sigma=1) - gaussian(im_grayscale, sigma=3), axis=2)
+        sub_descriptors = np.append(sub_descriptors, dog, axis=2)
+        sub_descriptors = sub_descriptors.reshape(
+            (sub_descriptors.shape[0] * sub_descriptors.shape[1], sub_descriptors.shape[2]))
+
+        codewords = kmeans.predict(sub_descriptors)
+        counts = np.bincount(codewords, minlength=cluster_count)
+
+        # Perform normalization
+        if normalized:
+            counts = counts / cluster_count
+
+        chunk_matrix[i, :] = counts
+
+    return coords, chunk_matrix
+
+
 class Texton(Feature):
     """Texton feature."""
 
-    def __init__(self,
-                 kmeans: MiniBatchKMeans,
-                 windows=((25, 25), ),
-                 normalized=True):
+    def __init__(self, kmeans: MiniBatchKMeans, windows=((25, 25),), normalized=True):
         super(Texton, self)
         self.windows = windows
         self.kmeans = kmeans
@@ -88,37 +115,23 @@ class Texton(Feature):
         self.normalized = normalized
         self.descriptors = None
 
-    def __call__(self, cell):
-        result = np.zeros(self.feature_size)
-        n_clusters = self.kmeans.n_clusters
-        for i, window in enumerate(self.windows):
-            win = cell.super_cell(window, padding=True)
-            start_index = i * n_clusters
-            end_index = (i + 1) * n_clusters
-            result[start_index:end_index] = self.texton(win)
-        return result
+    def __call__(self, chunk):
+        return texton_for_chunk(chunk, self.kmeans, self.normalized)
 
     def __str__(self):
-        normalized = "normalized" if self.normalized else "not-normalized"
-        return "Texton1-dog-{}-{}".format(str(self.windows), normalized)
+        normalized = "n" if self.normalized == True else "nn"
+        return "Te-{}-{}".format(str(self.windows), normalized)
 
-    def initialize(self, sat_image: SatelliteImage):
-        """Compute texton descriptors for the image."""
-        self.descriptors = get_texton_descriptors(sat_image.grayscale)
+    def chunk_size(self, cpu_cnt, im_shape):
+        return im_shape[0]
 
-    def texton(self, window: Cell):
-        """Calculate the texton feature on the given window."""
-        cluster_count = self.kmeans.n_clusters
+    def initialize(self, generator: CellGenerator, scale):
+        im_grayscale = generator.image.grayscale
 
-        descriptors = self.descriptors[window.x_range, window.y_range, :]
-        shape = descriptors.shape
-        descriptors = descriptors.reshape(shape[0] * shape[1], shape[2])
+        data = []
+        for window in generator:
+            im, x_range, y_range = super_cell(im_grayscale, scale, window.x_range, window.y_range, padding=True)
+            processing_tuple = (window.x, window.y, im)
+            data.append(processing_tuple)
 
-        codewords = self.kmeans.predict(descriptors)
-        counts = np.bincount(codewords, minlength=cluster_count)
-
-        # Perform normalization
-        if self.normalized:
-            counts = counts / cluster_count
-
-        return counts
+        return data

--- a/satsense/util/cache.py
+++ b/satsense/util/cache.py
@@ -1,0 +1,147 @@
+from sklearn.externals import joblib
+import numpy as np
+import os
+
+from satsense.features import FeatureSet
+from satsense.util.path import get_project_root
+
+
+def cache_model(model, filename):
+    dir_path = "{root}/cache".format(
+        root=get_project_root(),
+    )
+
+    if not os.path.isdir(dir_path):
+        os.mkdir(dir_path)
+
+    full_path = "{dir_path}/{file}.pkl".format(
+        dir_path=dir_path,
+        file=filename,
+    )
+
+    joblib.dump(model, full_path)
+
+
+def cached_model_exists(filename):
+    full_path = "{root}/cache/{file}.pkl".format(
+        root=get_project_root(),
+        file=filename,
+    )
+
+    if os.path.exists(full_path):
+        return True
+
+    return False
+
+
+def load_cached_model(filename: str):
+    full_path = "{root}/cache/{file}.pkl".format(
+        root=get_project_root(),
+        file=filename,
+    )
+
+    return joblib.load(full_path)
+
+
+def cache(array, filename):
+    try:
+        dir_path = cache_path()
+        if not os.path.isdir(dir_path):
+            os.mkdir(dir_path)
+
+        print("Cached: {}".format(filename))
+        np.save(dir_path + '/' + filename + ".npy", array)
+    except OSError:
+        print("Cannot cache - to long filename")
+        pass
+
+
+
+def load_cache(filename):
+    full_file_path = get_project_root() + "/cache/" + filename + '.npy'
+
+    if not os.path.exists(full_file_path):
+        return None
+
+    print("Loaded cached: {}".format(filename))
+    return np.load(full_file_path)
+
+
+def load_to_cache(features):
+    # Add feature keys
+    to_cache = {}
+    for name, feature in features.items.items():
+        to_cache[name] = {}
+    return to_cache
+
+
+def load_feature_cache(features: FeatureSet, image_name: str, window_size: (int, int)) -> dict:
+    cached = {}
+    for name, feature in features.items.items():
+        feature_cache_key = "{feature}{fwindow}-window{window}-image-{image_name}".format(
+            image_name=image_name,
+            fwindow=str(feature.windows),
+            window=window_size,
+            feature=str(feature),
+        )
+        full_path = "{root}/cache/features/{feature}/{cache_key}.npz".format(
+            root=get_project_root(),
+            feature=str(feature),
+            cache_key=feature_cache_key
+        )
+
+        try:
+            if os.path.isfile(full_path):
+                npzdict = np.load(full_path)
+                cached[name] = npzdict
+            else:
+                cached[name] = {}
+        except OSError:
+            cached[name] = {}
+
+    return cached
+
+
+def make_feature_cache_key(feature, image_name, window, window_size):
+    return "feature-window.x={x}-window.y={y}-{feature}{fwindow}-window{window}-image-{image_name}".format(
+        image_name=image_name,
+        fwindow=str(feature.windows),
+        window=window_size,
+        feature=str(feature),
+        x=window.x,
+        y=window.y,
+    )
+
+
+def cache_calculated_features(features, image_name, to_cache, window_size):
+    for name, feature in features.items.items():
+        feature_cache_key = "{feature}{fwindow}-window{window}-image-{image_name}".format(
+            image_name=image_name,
+            fwindow=str(feature.windows),
+            window=window_size,
+            feature=str(feature),
+        )
+
+        dir_path = "{root}/cache/features/{feature}".format(
+            feature=str(feature),
+            root=get_project_root(),
+        )
+        full_path = "{dir_path}/{cache_key}.npz".format(
+            dir_path=dir_path,
+            cache_key=feature_cache_key,
+        )
+        os.makedirs(os.path.dirname(full_path), exist_ok=True)
+        if not os.path.isdir(dir_path):
+            os.mkdir(dir_path)
+
+        arrays = to_cache[name]
+        np.savez(full_path, **arrays)
+
+
+def cache_path():
+    cache_path = get_project_root() + "/cache"
+    return cache_path
+
+
+def cache_file_exists(cache_key):
+    return os.path.exists(cache_key)


### PR DESCRIPTION
Multiprocessing enabled features...
Idea is to setup precise data chunks that will be processed, in the 'intialize' function of a feature.
This is a list of tuples, every feature needs a different tuple but mostly it is
`(x, y, image_of_type)`

Where x, y, are the coordinates of the block, image_of_type is a numpy array of for example the canny-edged image for that scale and block, which the feature needs for its computations

Then the feature takes in its `__call__` a list of these tuples, which is a subset of the whole list, this is a 'chunk' of computations which should happen in this process.

Then every chunk computation returns an array of coordinates (N, 2) where every row are the x,y, coordinates and a matrix which is (N, K), where K are the calculated features for these coordinates

Processing is done per scale at a time, this makes it easier to keep track of what you're doing and where the numbers should be placed in the matrix (because of variable feature lengths and then multiple scales)



Since you asked for some of the parameters I run the program with:

These are the optimal feature scales:
```  
    ("LACUNARITY", (50, 300, 500)),
    ("PANTEX", (100, 300, 500)),
    ("SIFT", (100, 200, 300)),
    ("TEXTON", (50, 100, 200)),
```

RobustScaler from scikit-learn.
SMOTE oversampler from imblearn

Main window size of (10x10, 20x20 or 30x30)
Feature parameters are all the defaults as they are in the code.
