### PR TITLE
Fixes nodata bug in SatelliteImage.load_from_file

### DIFF
--- a/satsense/image.py
+++ b/satsense/image.py
@@ -198,7 +198,10 @@ class SatelliteImage(Image):
                 image The image loaded as a numpy array
         """
         dataset = gdal.Open(path, gdal.GA_ReadOnly)
+        band = dataset.GetRasterBand(1)
+        
         array = dataset.ReadAsArray()
+        array[array == band.GetNoDataValue()] = 0
 
         if len(array.shape) == 3:
             # The bands column is in the first position, but we want it last


### PR DESCRIPTION
Wanneer je een satelliet beeld inlaad in satsense kan je op de randen van de afbeelding stukken hebben die niet zijn gedefineerd met waarden. Deze stukken krijgen een zo genaamde 'nodata' value. In het geval van de satellietbeelden die ik gebruikt heb is de nodata waarde ongeveer 10e+37. Wanneer ik dit beeld in satsense laat zien via een imshow, wordt de afbeelding genormaliseert tussen 0 en 1. Hierdoor zijn alle waarden enorm klein geworden waardoor de afbeelding volledig zwart is met uitzondering van de randen. Deze fix zet alle nodata waarden op 0 in plaats van 10e+37 zodat deze problemen verholpen worden