### PR TITLE
fix empty mappingproxy

### DIFF
--- a/satsense/image.py
+++ b/satsense/image.py
@@ -154,6 +154,8 @@ class Image:
                         band, self.filename, self.normalization_parameters,
                         limits))
 
+            if not bool(self.normalization):
+                self.normalization = {}  # overwrite mappingproxy with dict
             self.normalization[band] = limits
 
         return self.normalization[band]


### PR DESCRIPTION
self.normalization could be an empty mappingproxy. We cannot add attributes to the empty mappingproxy. If it is an empty mappingproxy, redefine it as en empty dictionary.